### PR TITLE
storage: Fix obvious identifier typos

### DIFF
--- a/src/eiffel_graphql_api/storage.py
+++ b/src/eiffel_graphql_api/storage.py
@@ -47,11 +47,11 @@ if __name__ == "__main__":
         "password": os.getenv("RABBITMQ_PASSWORD", None),
         "port": int(os.getenv("RABBITMQ_PORT", "5672")),
         "vhost": os.getenv("RABBITMQ_VHOST", None),
-        "ssl": ssl,
+        "ssl": SSL,
         "queue": os.getenv("RABBITMQ_QUEUE", None),
         "routing_key": "#"
     }
-    SUBSCRIBER = RabbitMQSubscriber(**data)
+    SUBSCRIBER = RabbitMQSubscriber(**DATA)
     SUBSCRIBER.subscribe("*", insert_to_db)
     SUBSCRIBER.start()
 


### PR DESCRIPTION
### Applicable Issues
N/A; fix for obvious bug.

### Description of the Change
storage.py contains typos that prevents it from working standalone.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.5/site-packages/eiffel_graphql_api/storage.py", line 50, in <module>
    "ssl": ssl,
NameError: name 'ssl' is not defined
```
And after fixing that one:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.5/site-packages/eiffel_graphql_api/storage.py", line 54, in <module>
    SUBSCRIBER = RabbitMQSubscriber(**data)
NameError: name 'data' is not defined
```

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
