### PR TITLE
database: Add MongoDB auth support via MONGODB_{USERNAME,PASSWORD}

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -16,6 +16,8 @@ Initialize terminal
     export RABBITMQ_QUEUE=
     export MONGODB_HOST=
     export MONGODB_PORT=
+    export MONGODB_USERNAME=
+    export MONGODB_PASSWORD=
     export MONGODB_REPLICASET=
     export DATABASE_NAME=
 

--- a/src/eiffel_graphql_api/graphql/db/database.py
+++ b/src/eiffel_graphql_api/graphql/db/database.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import urllib.parse
+
 import pymongo
 
 DATABASE = None
@@ -24,6 +26,8 @@ def connect(mock):
     global DATABASE, CLIENT
     host = os.getenv("MONGODB_HOST", "localhost")
     port = os.getenv("MONGODB_PORT", "27017")
+    username = os.getenv("MONGODB_USERNAME")
+    password = os.getenv("MONGODB_PASSWORD")
     database_name = os.getenv("DATABASE_NAME", "this_is_not_correct")
     replicaset = os.getenv("MONGODB_REPLICASET") or None
 
@@ -33,8 +37,13 @@ def connect(mock):
     else:
         mongo_client = pymongo.MongoClient
 
-    CLIENT = mongo_client("mongodb://{}:{}".format(host, port),
-                          replicaset=replicaset)
+    if username and password:
+        url = "mongodb://{}:{}@{}:{}".format(urllib.parse.quote(username),
+                                             urllib.parse.quote(password),
+                                             host, port)
+    else:
+        url = "mongodb://{}:{}".format(host, port),
+    CLIENT = mongo_client(url, replicaset=replicaset)
     DATABASE = CLIENT[database_name]
 
 


### PR DESCRIPTION
### Applicable Issues
Fixes #12 

### Description of the Change
MongoDB databases typically require authentication, so read the MONGODB_{USERNAME,PASSWORD} environment variables and include them in the connection URL.

### Alternate Designs
None. There are downsides with using environment variables for passing credentials (and configuration values in general) but let's follow the pattern already established for the RabbitMQ configuration.

### Benefits
Possibility to connect to MongoDB servers requiring authentication :-)

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck <<magnus.back@axis.com>>
