### PR TITLE
storage: By default don't enable TLS for RabbitMQ

### DIFF
--- a/src/eiffel_graphql_api/storage.py
+++ b/src/eiffel_graphql_api/storage.py
@@ -39,7 +39,7 @@ def insert_to_db(event, context):
 
 if __name__ == "__main__":
     DATABASE = get_database()
-    SSL = os.getenv("RABBITMQ_SSL", "true") == "true"
+    SSL = os.getenv("RABBITMQ_SSL", "false") == "true"
     DATA = {
         "host": os.getenv("RABBITMQ_HOST", "127.0.0.1"),
         "exchange": os.getenv("RABBITMQ_EXCHANGE", "eiffel"),


### PR DESCRIPTION
### Applicable Issues
Fixes #11 

### Description of the Change
The default value of RABBITMQ_SSL used to be true, which is awkward since RABBITMQ_HOST defaults to 127.0.0.1 and RABBITMQ_PORT defaults to 5672 (i.e. the non-TLS AMQP port), so even if you could get away with using the default values for the host and port variables you still had to disable TLS.

### Alternate Designs
We could leave TLS enabled by default and instead change the port number to 5671, but with a default hostname of 127.0.0.1 you'd effectively force people to either override the host or disable TLS (few people run TLS locally).

### Benefits
Decreased risk of misconfigurations.

### Possible Drawbacks
This change isn't backwards compatible; people relying on the old default value are in for a surprise.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is     maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck <<magnus.back@axis.com>>
