### PR TITLE
storage: Use event id as document id when inserting to MongoDB

### DIFF
--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,40 @@
+# Copyright 2020 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# -*- coding: utf-8 -*-
+
+from eiffellib.events.eiffel_composition_defined_event import EiffelCompositionDefinedEvent
+
+from eiffel_graphql_api import storage
+from eiffel_graphql_api.graphql.db.database import get_database
+
+
+def test_storage_insert_single_doc():
+    storage.DATABASE = get_database(True)
+    event = EiffelCompositionDefinedEvent()
+
+    assert storage.insert_to_db(event, None)
+    collection = storage.DATABASE[event.meta.type]
+    result = collection.find_one({"_id": event.meta.event_id})
+    del result["_id"]
+    assert result == event.json
+
+
+def test_storage_ignores_duplicate_ids():
+    storage.DATABASE = get_database(True)
+    event = EiffelCompositionDefinedEvent()
+
+    assert storage.insert_to_db(event, None)
+    assert not storage.insert_to_db(event, None)


### PR DESCRIPTION
### Applicable Issues
Fixes #10 

### Description of the Change
When storing an event in a MongoDB collection don't let MongoDB allocate a random document id. Instead use the event id as the document id and catch any DuplicateKeyError errors that might pop up. Unless you have events with duplicate ids sent on the bus such errors are harmless and typically indicate that a message was delivered twice.

We also change insert_to_db() to return a bool indicate whether a document was actually inserted. If nothing else this is useful in the tests.

### Alternate Designs
No other alternatives were considered.

### Benefits
No duplicate events stored in the database.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck <<magnus.back@axis.com>>
