### PR TITLE
Retry all MongoDB operations.

### DIFF
--- a/src/eiffel_graphql_api/graphql/db/database.py
+++ b/src/eiffel_graphql_api/graphql/db/database.py
@@ -13,16 +13,30 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Database handler functions."""
 import os
+import logging
+import time
+import math
 import urllib.parse
+from threading import Lock
 
 import pymongo
 
 DATABASE = None
 CLIENT = None
+LOCK = Lock()
+LOGGER = logging.getLogger("Database")
+RETRY_TIMEOUT = os.getenv("MONGODB_RECONNECT_TIMEOUT") or math.inf
+# pylint: disable=global-statement
 
 
 def connect(mock):
+    """Connect and wait for connection to MongoDB.
+
+    :param mock: Whether the server should be mocked or not. Used for tests.
+    :type mock: bool
+    """
     global DATABASE, CLIENT
     host = os.getenv("MONGODB_HOST", "localhost")
     port = os.getenv("MONGODB_PORT", "27017")
@@ -30,8 +44,10 @@ def connect(mock):
     password = os.getenv("MONGODB_PASSWORD")
     database_name = os.getenv("DATABASE_NAME", "this_is_not_correct")
     replicaset = os.getenv("MONGODB_REPLICASET") or None
+    LOGGER.info("Connecting to %r:%r", host, port)
 
     if mock:
+        # pylint: disable=import-outside-toplevel, import-error
         import mongomock
         mongo_client = mongomock.MongoClient
     else:
@@ -42,20 +58,98 @@ def connect(mock):
                                              urllib.parse.quote(password),
                                              host, port)
     else:
-        url = "mongodb://{}:{}".format(host, port),
+        url = "mongodb://{}:{}".format(host, port)
     CLIENT = mongo_client(url, replicaset=replicaset)
     DATABASE = CLIENT[database_name]
+    # 'server_info' will create a connection against the MongoDB effectively testing
+    # the connection for us. This means that the 'connect' method will block until
+    # a connection can be established or 'ServerSelectionTimeoutError' is raised.
+    LOGGER.info("%r", CLIENT.server_info())
+    LOGGER.info("Connected.")
+
+
+def retry(fixture, timeout, *args, **kwargs):
+    """Retry call to fixture for 'timeout' seconds.
+
+    :param fixture: Fixture to call upon.
+    :type fixture: :obj:`func`
+    :param timeout: How long to wait for fixture to succeed. In seconds.
+    :type timeout: float
+    :param args: Positional argument to pass onto fixture.
+    :type args: tuple
+    :param kwargs: Keyword arguments to pass onto fixture.
+    :type kwargs: dict
+    """
+    end = time.time() + timeout
+    while time.time() < end:
+        try:
+            fixture(*args, **kwargs)
+            break
+        except Exception as exception:  # pylint:disable=broad-except
+            LOGGER.warning("%r", exception)
+            LOGGER.warning("Retrying %r", fixture)
+            time.sleep(0.1)
+    else:
+        raise TimeoutError("Timeout after %rs calling fixture %r" % (timeout, fixture))
 
 
 def get_database(mock=False):
+    """Create and wait for a database connection.
+
+    :param mock: Whether the server should be mocked or not. Used for tests.
+    :type mock: bool
+    :return: Database instance.
+    :rtype: :obj:`pymongo.MongoClient.collection`
+    """
     global DATABASE
     if DATABASE is None:
-        connect(mock)
+        retry(connect, float(RETRY_TIMEOUT), mock)
     return DATABASE
 
 
 def get_client(mock=False):
+    """Create and wait for a client connection.
+
+    :param mock: Whether the server should be mocked or not. Used for tests.
+    :type mock: bool
+    :return: Client instance.
+    :rtype: :obj:`pymongo.MongoClient`
+    """
     global CLIENT
     if CLIENT is None:
-        connect(mock)
+        retry(connect, float(RETRY_TIMEOUT), mock)
     return CLIENT
+
+
+def insert_to_db(event, _=None):
+    """Eiffel callback for storing events in database.
+
+    :param event: Event to store into database.
+    :type event: :obj:`eiffellib.events.eiffel_base_event.EiffelBaseEvent`
+    :param context: In which context was the event sent.
+    :type context: str
+    :return: Whether or not database insertion succeeded.
+    :rtype: bool
+    """
+    global DATABASE
+    if DATABASE is None:
+        with LOCK:
+            DATABASE = get_database()
+        return False  # Requeue event if DATABASE is not ready.
+    try:
+        collection = DATABASE[event.meta.type]
+        collection.create_index([("meta.id", pymongo.ASCENDING)])
+        collection.create_index([("links.target", pymongo.ASCENDING)])
+        doc = event.json
+        doc['_id'] = event.meta.event_id
+        collection.insert_one(doc)
+    except pymongo.errors.DuplicateKeyError:
+        LOGGER.warning("Event already exists in the database, "
+                       "skipping: %r", event.json)
+        return True
+    except Exception as exception:  # pylint:disable=broad-except
+        LOGGER.warning("%r", exception)
+        with LOCK:
+            DATABASE = None
+        return False
+    return True

--- a/src/eiffel_graphql_api/graphql/db/database.py
+++ b/src/eiffel_graphql_api/graphql/db/database.py
@@ -24,6 +24,7 @@ import pymongo
 
 DATABASE = None
 CLIENT = None
+LOCK = Lock()
 LOGGER = logging.getLogger(__name__)
 RETRY_TIMEOUT = os.getenv("MONGODB_RECONNECT_TIMEOUT") or math.inf
 # pylint: disable=global-statement
@@ -57,8 +58,9 @@ def connect(mock):
                                              host, port)
     else:
         url = "mongodb://{}:{}".format(host, port)
-    CLIENT = mongo_client(url, replicaset=replicaset)
-    DATABASE = CLIENT[database_name]
+    with LOCK:
+        CLIENT = mongo_client(url, replicaset=replicaset)
+        DATABASE = CLIENT[database_name]
     # 'server_info' will create a connection against the MongoDB effectively testing
     # the connection for us. This means that the 'connect' method will block until
     # a connection can be established or 'ServerSelectionTimeoutError' is raised.

--- a/src/eiffel_graphql_api/storage.py
+++ b/src/eiffel_graphql_api/storage.py
@@ -13,13 +13,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""DB Storage tool for eiffel graphql API."""
+import argparse
 import os
+import sys
 import time
-import pymongo
-from eiffel_graphql_api.graphql.db.database import get_database
+import logging
 from eiffellib.subscribers.rabbitmq_subscriber import RabbitMQSubscriber
+from eiffel_graphql_api.graphql.db.database import insert_to_db
+from eiffel_graphql_api import __version__
 
-DATABASE = None
+LOGGER = logging.getLogger("Storage")
 
 # Set environment variables from rabbitmq secrets in a kubernetes cluster.
 if os.path.isfile("/etc/rabbitmq/password"):
@@ -30,39 +34,76 @@ if os.path.isfile("/etc/rabbitmq/username"):
         os.environ["RABBITMQ_USERNAME"] = username.read()
 
 
-def insert_to_db(event, context):
-    print(event)
-    collection = DATABASE[event.meta.type]
-    collection.create_index([("meta.id", pymongo.ASCENDING)])
-    collection.create_index([("links.target", pymongo.ASCENDING)])
-    doc = event.json
-    doc['_id'] = event.meta.event_id
-    try:
-        collection.insert_one(doc)
-    except pymongo.errors.DuplicateKeyError:
-        print("Event already exists in the database, "
-              "skipping: {}".format(event.json))
-        return False
-    return True
+def parse_args(args):
+    """Parse command line parameters
+
+    :param args: Commandl ine parameters as list of strings.
+    :type args: list
+    :return: Command line parameters namespace.
+    :rtype: :obj:`argparse.Namespace
+    """
+    parser = argparse.ArgumentParser(
+        description="Tool for storing eiffel events in a Mongo database.")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="eiffel-graphql-storage {ver}".format(ver=__version__))
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="loglevel",
+        help="set loglevel to DEBUG",
+        action="store_const",
+        default=logging.INFO,
+        const=logging.DEBUG)
+    return parser.parse_args(args)
 
 
-if __name__ == "__main__":
-    DATABASE = get_database()
-    SSL = os.getenv("RABBITMQ_SSL", "false") == "true"
-    DATA = {
+def setup_logging(loglevel):
+    """Setup basic logging
+
+    :param loglevel: Minimum loglevel for emitting messages.
+    :type loglevel: int
+    """
+    logformat = "[%(asctime)s] %(levelname)s:%(message)s"
+    logging.basicConfig(level=loglevel, stream=sys.stdout,
+                        format=logformat, datefmt="%Y-%m-%d %H:%M:%S")
+
+
+def main(args):
+    """Start GraphQL storage tool, connect to MongoDB and subscribe to Eiffel.
+
+    :param args: Input arguments to storage tool.
+    :type args: list
+    """
+    args = parse_args(args)
+    setup_logging(args.loglevel)
+
+    ssl = os.getenv("RABBITMQ_SSL", "false") == "true"
+    data = {
         "host": os.getenv("RABBITMQ_HOST", "127.0.0.1"),
         "exchange": os.getenv("RABBITMQ_EXCHANGE", "eiffel"),
         "username": os.getenv("RABBITMQ_USERNAME", None),
         "password": os.getenv("RABBITMQ_PASSWORD", None),
         "port": int(os.getenv("RABBITMQ_PORT", "5672")),
         "vhost": os.getenv("RABBITMQ_VHOST", None),
-        "ssl": SSL,
+        "ssl": ssl,
         "queue": os.getenv("RABBITMQ_QUEUE", None),
         "routing_key": "#"
     }
-    SUBSCRIBER = RabbitMQSubscriber(**DATA)
-    SUBSCRIBER.subscribe("*", insert_to_db)
-    SUBSCRIBER.start()
+    subscriber = RabbitMQSubscriber(**data)
+    subscriber.subscribe("*", insert_to_db, can_nack=True)
+    subscriber.start()
 
     while True:
         time.sleep(0.1)
+
+
+def run():
+    """Entry point for console_scripts
+    """
+    main(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    run()

--- a/src/eiffel_graphql_api/storage.py
+++ b/src/eiffel_graphql_api/storage.py
@@ -23,7 +23,7 @@ from eiffellib.subscribers.rabbitmq_subscriber import RabbitMQSubscriber
 from eiffel_graphql_api.graphql.db.database import insert_to_db
 from eiffel_graphql_api import __version__
 
-LOGGER = logging.getLogger("Storage")
+LOGGER = logging.getLogger(__name__)
 
 # Set environment variables from rabbitmq secrets in a kubernetes cluster.
 if os.path.isfile("/etc/rabbitmq/password"):


### PR DESCRIPTION
Wait for connection when creating the first connection to MongoDB.
If connection goes down during event parsing, start a new connection.
Moved MongoDB related code to database.py to make it easier to change
database in the future, if needed.
Started using logging instead of print

<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
Fixes: #18 

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Added retries to all GraphQL operations

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
Could move the entire database handling to a class instead of a module.

### Benefits
<!-- What benefits will be realized by the change? -->
More reliability in storage.py

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
A lot of threads started in eiffellib

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobiaspn@axis.com>
