### PR TITLE
Don't format meta.time field

### DIFF
--- a/src/eiffel_graphql_api/graphql/schemas/lib/bigint.py
+++ b/src/eiffel_graphql_api/graphql/schemas/lib/bigint.py
@@ -1,0 +1,40 @@
+# Copyright 2020 Axis Communications AB.
+#
+# For a full list of individual contributors, please see the commit history.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from graphql.language import ast
+from graphene.types import Scalar
+from graphene.types.scalars import MIN_INT, MAX_INT
+
+class BigInt(Scalar):
+    """
+    BigInt is an extension of the regular Int field
+        that supports Integers bigger than a signed
+        32-bit integer.
+    """
+    @staticmethod
+    def serializer(value):
+        """Override the standard serializer to not raise exceptions on MAX_INT."""
+        return int(value)
+
+    serialize = serializer
+    parse_value = serializer
+
+    @staticmethod
+    def parse_literal(node):
+        if isinstance(node, ast.IntValue):
+            num = int(node.value)
+            if num > MAX_INT or num < MIN_INT:
+                return float(int(num))
+            return num


### PR DESCRIPTION


<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes: #28 

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
The meta.time field was formatted for humans during development and
that should now be removed since it will be mostly machines getting
data from the API.

GraphQL does not support integers larger than 32-bit signed so a new
BigInt scalar was created for this.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
We could just keep it as it was with human readable datetimes

### Benefits
<!-- What benefits will be realized by the change? -->
More closely follows the eiffel specification and returns what a user of eiffel expects it to return.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
More difficult for a human to look at the API view.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobiaspn@axis.com>
