### PR TITLE
Fix broken tests

### DIFF
--- a/src/eiffel_graphql_api/graphql/db/database.py
+++ b/src/eiffel_graphql_api/graphql/db/database.py
@@ -74,7 +74,7 @@ def get_database(mock=False):
     :param mock: Whether the server should be mocked or not. Used for tests.
     :type mock: bool
     :return: Database instance.
-    :rtype: :obj:`pymongo.MongoClient.collection`
+    :rtype: :obj:`pymongo.database.Database`
     """
     if DATABASE is None:
         connect(mock)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,8 +18,18 @@ import os
 import threading
 import pytest
 from eiffel_graphql_api.graphql.api import APP
+from eiffel_graphql_api.graphql.db.database import get_database
 from eiffel_graphql_api.graphql.db.database import get_client
 
+
+@pytest.fixture
+def mock_mongo():
+    """Inject a MongoDB client connected to a mock server with no database
+    in place, guaranteeing that we'll start from a clean slate.
+    """
+    client = get_client(mock=True)
+    client.drop_database(os.getenv("DATABASE_NAME"))
+    yield get_database(mock=True)
 
 
 def start():

--- a/tests/test_events/activity_canceled/test_activity_canceled.py
+++ b/tests/test_events/activity_canceled/test_activity_canceled.py
@@ -118,4 +118,4 @@ class TestActivityCanceled(TestCase):
         self.assertEqual(meta.get("version"), "3.0.0")
         self.assertEqual(meta.get("type"), "EiffelActivityCanceledEvent")
         self.assertEqual(meta.get("id"), "6a1abb6e-2c13-4a82-8fe2-012f8fe7c541")
-        self.assertEqual(meta.get("time"), "2019-12-10T08:32:35.892000")
+        self.assertEqual(meta.get("time"), 1575963155892)

--- a/tests/test_events/activity_finished/test_activity_finished.py
+++ b/tests/test_events/activity_finished/test_activity_finished.py
@@ -157,4 +157,4 @@ class TestActivityFinished(TestCase):
         self.assertEqual(meta.get("version"), "3.0.0")
         self.assertEqual(meta.get("type"), "EiffelActivityFinishedEvent")
         self.assertEqual(meta.get("id"), "bc73b474-4f5c-4931-b7d5-8588d0a6534a")
-        self.assertEqual(meta.get("time"), "2019-12-10T09:09:47.254000")
+        self.assertEqual(meta.get("time"), 1575965387254)

--- a/tests/test_events/activity_triggered/test_activity_triggered.py
+++ b/tests/test_events/activity_triggered/test_activity_triggered.py
@@ -128,7 +128,7 @@ class TestActivityTriggered(TestCase):
         self.assertEqual(meta.get("version"), "3.0.0")
         self.assertEqual(meta.get("type"), "EiffelActivityTriggeredEvent")
         self.assertEqual(meta.get("id"), "6a1abb6e-2c13-4a82-8fe2-012f8fe7c541")
-        self.assertEqual(meta.get("time"), "2019-12-09T13:43:57.093000")
+        self.assertEqual(meta.get("time"), 1575895437093)
 
     def test_activity_triggered_links(self):
         """Test that it is possible to query 'links' from activity triggered.

--- a/tests/test_events/announcement_published/test_announcement_published.py
+++ b/tests/test_events/announcement_published/test_announcement_published.py
@@ -135,4 +135,4 @@ class TestAnnouncementPublished(TestCase):
         self.assertEqual(meta.get("version"), "3.0.0")
         self.assertEqual(meta.get("type"), "EiffelAnnouncementPublishedEvent")
         self.assertEqual(meta.get("id"), "4baf56e6-404a-4132-a28b-9ed782f26293")
-        self.assertEqual(meta.get("time"), "2019-12-10T09:34:25.708000")
+        self.assertEqual(meta.get("time"), 1575966865708)

--- a/tests/test_events/artifact_created/test_artifact_created.py
+++ b/tests/test_events/artifact_created/test_artifact_created.py
@@ -210,4 +210,4 @@ class TestArtifactCreated(TestCase):
         self.assertEqual(meta.get("version"), "3.0.0")
         self.assertEqual(meta.get("type"), "EiffelArtifactCreatedEvent")
         self.assertEqual(meta.get("id"), "730f8573-cd69-41f5-81ad-d85aebf28d03")
-        self.assertEqual(meta.get("time"), "2019-12-10T09:57:08.603000")
+        self.assertEqual(meta.get("time"), 1575968228603)

--- a/tests/test_events/artifact_published/test_artifact_published.py
+++ b/tests/test_events/artifact_published/test_artifact_published.py
@@ -129,4 +129,4 @@ class TestArtifactPublished(TestCase):
         self.assertEqual(meta.get("version"), "3.0.0")
         self.assertEqual(meta.get("type"), "EiffelArtifactPublishedEvent")
         self.assertEqual(meta.get("id"), "031c2f9a-92f0-4cac-9320-e0113adafd7d")
-        self.assertEqual(meta.get("time"), "2019-12-10T13:34:15.471000")
+        self.assertEqual(meta.get("time"), 1575981255471)

--- a/tests/test_events/artifact_reused/test_artifact_reused.py
+++ b/tests/test_events/artifact_reused/test_artifact_reused.py
@@ -136,4 +136,4 @@ class TestArtifactReused(TestCase):
         self.assertEqual(meta.get("version"), "3.0.0")
         self.assertEqual(meta.get("type"), "EiffelArtifactReusedEvent")
         self.assertEqual(meta.get("id"), "0284875e-4f2f-4589-b6df-797afb039b88")
-        self.assertEqual(meta.get("time"), "2019-12-10T14:38:34.977000")
+        self.assertEqual(meta.get("time"), 1575985114977)


### PR DESCRIPTION
### Applicable Issues
Fixes #33 

### Description of the Change
Two recent commits, b1ea2a5 and d248c4c each broke the tests in different ways. Most failed tests stemmed from the latter commit and were trivial to address.

The first commit refactored storage.py and moved some functions to database.py, so we move the test file accordingly. The API of insert_to_db() was also changed to return True if the document was ignored because it was already present in the database. That made sense but broke the test which relied on the return value to determine whether the document was inserted. It was rewritten to count the documents in the collection to make that determination. This prompted the addition of a pytest fixture, mock_mongo, that injects a fresh MongoDB database into the test.

### Alternate Designs
None.

### Benefits
Tests will once again be green.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
