### PR TITLE
storage.py: Support RABBITMQ_DURABLE_QUEUE env variable

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -14,6 +14,7 @@ Initialize terminal
     export RABBITMQ_PORT=
     export RABBITMQ_VHOST=
     export RABBITMQ_QUEUE=
+    export RABBITMQ_DURABLE_QUEUE=
     export MONGODB_CONNSTRING=
     export MONGODB_DATABASE=
 

--- a/src/eiffel_graphql_api/storage.py
+++ b/src/eiffel_graphql_api/storage.py
@@ -96,6 +96,9 @@ def main(args):
         "ssl": ssl,
         "queue": os.getenv("RABBITMQ_QUEUE", None),
         "routing_key": "#",
+        "queue_params": {
+            "durable": os.getenv("RABBITMQ_DURABLE_QUEUE", "false") == "true"
+        },
     }
     subscriber = RabbitMQSubscriber(**data)
     subscriber.subscribe("*", insert_to_db, can_nack=True)


### PR DESCRIPTION
### Applicable Issues
Fixes #43 

### Description of the Change
There are very few reasons why one wouldn't want to use a durable queue when consuming events and storing in a database and previously we haven't supported that. Since flipping the durable queue parameter is a breaking change we make it opt-in via a new RABBITMQ_DURABLE_QUEUE environment variable. If we ever flip the program's major version we can change its default to true.

### Alternate Designs
Considered skipping the environment variable and always setting durable to true, but that would break any existing deployment. You can't change that parameter of an existing queue so it's a tedious change to make. Let's allow people to make that transition when convenient.

### Benefits
Durable queues survive broker restarts.

### Possible Drawbacks
None.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
