### PR TITLE
Depend on pymongo[srv] to add support for mongodb+srv URLs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@
 #
 eiffellib==1.1.1
 requests==2.22.0
-pymongo==3.9.0
+pymongo[srv]==3.9.0
 graphql-core==2.2.1
 gql==0.1.0
 Flask==1.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ package_dir =
     =src
 # DON'T CHANGE THE FOLLOWING LINE! IT WILL BE UPDATED BY PYSCAFFOLD!
 setup_requires = pyscaffold>=3.2a0,<3.3a0
-install_requires = eiffellib==1.1.1;requests==2.22.0;pymongo==3.9.0;graphql-core==2.2.1;gql==0.1.0;Flask==1.1.1;Flask-GraphQL==2.0.0;graphene==2.1.8;gunicorn==20.0.4;gevent==1.4.0
+install_requires = eiffellib==1.1.1;requests==2.22.0;pymongo[srv]==3.9.0;graphql-core==2.2.1;gql==0.1.0;Flask==1.1.1;Flask-GraphQL==2.0.0;graphene==2.1.8;gunicorn==20.0.4;gevent==1.4.0
 
 [options.package_data]
 * = *.json


### PR DESCRIPTION
### Applicable Issues
Fixes #49 

### Description of the Change
mongodb+srv URLs depend DNS SRV records to figure out which hosts and ports to connect to pymongo needs additional packages (currently dnspython) for those lookups. By depending on `pymongo[srv]` instead of plain `pymongo` we request installation of whatever packages are needed for SRV lookups.

### Alternate Designs
None

### Benefits
Support mongodb+srv URLs that many users would want to use.

### Possible Drawbacks
At least one extra Python package will be installed.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
