### PR TITLE
Update ArtifactPublished schema to version 3.1.0

### DIFF
--- a/src/eiffel_graphql_api/graphql/schemas/events/json_schemas/EiffelArtifactPublishedEvent.json
+++ b/src/eiffel_graphql_api/graphql/schemas/events/json_schemas/EiffelArtifactPublishedEvent.json
@@ -15,8 +15,8 @@
         },
         "version": {
           "type": "string",
-          "enum": [ "3.0.0" ],
-          "default": "3.0.0"
+          "enum": [ "3.1.0" ],
+          "default": "3.1.0"
         },
         "time": {
           "type": "integer"
@@ -117,6 +117,9 @@
           "items": {
             "type": "object",
             "properties": {
+              "name": {
+                "type": "string"
+              },
               "type": {
                 "type": "string",
                 "enum": [


### PR DESCRIPTION
### Applicable Issues
Solves #58 

### Description of the Change
Updated EiffelArtifactPublished schema to version 3.1.0 (latest) and thus we gain access to the location.name property in the graphql API.

### Benefits
We can query the location.name property with the API.

### Possible Drawbacks
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Fredrik Fristedt \<fredrik.fristedt@axis.com\>
