### PR TITLE
Stop creating indexes each time a document is inserted

### DIFF
--- a/src/eiffel_graphql_api/graphql/db/database.py
+++ b/src/eiffel_graphql_api/graphql/db/database.py
@@ -115,14 +115,12 @@ def insert_to_db(event, _=None):
     try:
         database = get_database()
         collection = database[event.meta.type]
-        collection.create_index([("meta.id", pymongo.ASCENDING)])
-        collection.create_index([("links.target", pymongo.ASCENDING)])
         doc = event.json
         doc["_id"] = event.meta.event_id
         collection.insert_one(doc)
     except pymongo.errors.DuplicateKeyError:
         LOGGER.warning(
-            "Event already exists in the database, " "skipping: %r", event.json
+            "Event already exists in the database, skipping: %r", event.json
         )
         return True
     except pymongo.errors.ConnectionFailure as exception:

--- a/src/eiffel_graphql_api/graphql/db/database.py
+++ b/src/eiffel_graphql_api/graphql/db/database.py
@@ -119,9 +119,7 @@ def insert_to_db(event, _=None):
         doc["_id"] = event.meta.event_id
         collection.insert_one(doc)
     except pymongo.errors.DuplicateKeyError:
-        LOGGER.warning(
-            "Event already exists in the database, skipping: %r", event.json
-        )
+        LOGGER.warning("Event already exists in the database, skipping: %r", event.json)
         return True
     except pymongo.errors.ConnectionFailure as exception:
         LOGGER.warning("%r", exception)


### PR DESCRIPTION
### Applicable Issues
Fixes #54

### Description of the Change
We shouldn't treat the underlying database as something we own but rather see this application as one of many application that interact with an Eiffel event store. From that point of view it doesn't make sense to create indexes each time a document is created.

Although the fields we previously created indexes for should be indexed in pretty much any deployment most deployments will also want to index additional fields. Adding a configuration option to manage indexes in this application doesn't feel right, nor does spreading out index management in multiple places.

Hence, remove index creations from insert_to_db(). This should also improve performance.

### Alternate Designs
We considered adding tracking of which indexes we had created in the current session, but considered the bigger picture of index management for Eiffel event stores and figured that it doesn't belong here.

### Benefits
Less fragmented index management, better insertion performance.

### Possible Drawbacks
Users will have to take full ownership of their indexes. (But they'd probably have to deal with indexes outside of this application anyway.)

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I    have the right to submit it under the open source license    indicated in the file; or

(b) The contribution is based upon previous work that, to the best    of my knowledge, is covered under an appropriate open source    license and I have the right under that license to submit that    work with modifications, whether created in whole or in part    by me, under the same open source license (unless I am    permitted to submit under a different license), as indicated    in the file; or

(c) The contribution was provided directly to me by some other    person who certified (a), (b) or (c) and I have not modified    it.

(d) I understand and agree that this project and the contribution    are public and that a record of the contribution (including all    personal information I submit with it, including my sign-off) is    maintained indefinitely and may be redistributed consistent with    this project or the open source license(s) involved.

Signed-off-by: Magnus Bäck \<magnus.back@axis.com\>
