### PR TITLE
Fix a bug that occurs when specifying TERC links in TSS

### DIFF
--- a/src/eiffel_graphql_api/graphql/schemas/links/__init__.py
+++ b/src/eiffel_graphql_api/graphql/schemas/links/__init__.py
@@ -30,7 +30,7 @@ from .precursor import Precursor
 from .runtime_environment import RuntimeEnvironment
 from .source_change_base import *
 from .subject import Subject
-from .tercc import Tercc
+from .terc import Terc
 from .test_case_execution import *
 from .test_suite_execution import *
 from .verification_basis import VerificationBasis

--- a/src/eiffel_graphql_api/graphql/schemas/links/terc.py
+++ b/src/eiffel_graphql_api/graphql/schemas/links/terc.py
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Resolve tercc link."""
+"""Resolve terc link."""
 import graphene
 
 from eiffel_graphql_api.graphql.schemas.events import (
@@ -23,8 +23,8 @@ from eiffel_graphql_api.graphql.schemas.events import (
 from ..utils import find_one
 
 
-class Tercc(graphene.ObjectType):
-    """Tercc link."""
+class Terc(graphene.ObjectType):
+    """Terc link."""
 
     test_execution_recipe_collection_created = graphene.Field(
         TestExecutionRecipeCollectionCreated
@@ -36,7 +36,7 @@ class Tercc(graphene.ObjectType):
         self.link = link
 
     def resolve_test_execution_recipe_collection_created(self, _):
-        """Resolve tercc link."""
+        """Resolve terc link."""
         from ..union import NotFound  # pylint:disable=import-outside-toplevel
 
         event = find_one(

--- a/src/eiffel_graphql_api/graphql/schemas/links/utils.py
+++ b/src/eiffel_graphql_api/graphql/schemas/links/utils.py
@@ -31,7 +31,7 @@ from .precursor import Precursor
 from .runtime_environment import RuntimeEnvironment
 from .source_change_base import *
 from .subject import Subject
-from .tercc import Tercc
+from .terc import Terc
 from .test_case_execution import *
 from .test_suite_execution import *
 from .verification_basis import VerificationBasis
@@ -72,5 +72,5 @@ LINKS = {
     "CHANGE": SourceChange,
     "TEST_CASE_EXECUTION": TestCaseExecution,
     "TEST_SUITE_EXECUTION": TestSuiteExecution,
-    "TERCC": Tercc,
+    "TERC": Terc,
 }

--- a/src/eiffel_graphql_api/graphql/schemas/union.py
+++ b/src/eiffel_graphql_api/graphql/schemas/union.py
@@ -192,7 +192,7 @@ class EiffelLinkUnion(graphene.Union):  # pylint: disable=too-few-public-methods
             SourceSubmittedPreviousVersion,
             TestCaseExecution,
             TestSuiteExecution,
-            Tercc,
+            Terc,
         )
 
 


### PR DESCRIPTION
<!--
Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
Any pull request must pass the automated Travis tests and, if applicable, code style checks. In addition the pull request must  contain tests that cover the code.
-->

### Applicable Issues
<!-- Reference any relevant issues here. Every pull request must reference at least one issue to be considered (as per contribution guidelines) -->
fixes: #73 

### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
The link type is called TERC in eiffel schema files, but the eiffel graphql API spelled it TERCC, resulting in TSS events not links not being shown when TSS has these links.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
There are a few things that were considered in order to fix the "spelling error" of the eiffel specification. I.e. keep the name TERCC in the graphql API. But I believed that this would just cause confusion. We could also fix the "spelling error" in the specification itself. But that would be a non-backwards compatible change. 

### Benefits
<!-- What benefits will be realized by the change? -->
Events with TERC links will work in the ER.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
None

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
