### PR TITLE
Stop trying to use a base model for previous version links

### DIFF
--- a/src/eiffel_graphql_api/graphql/schemas/links/source_change_base.py
+++ b/src/eiffel_graphql_api/graphql/schemas/links/source_change_base.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Eiffel source change links."""
+
 import graphene
 
 from eiffel_graphql_api.graphql.schemas.events import (
@@ -68,9 +69,45 @@ class SourceChange(graphene.ObjectType):
         return SourceChangeCreated(event)
 
 
-class SourceSubmittedPreviousVersion(Base):
+class SourceSubmittedPreviousVersion(graphene.ObjectType):
     """Previous source submitted link."""
 
+    source_change_submitted = graphene.Field(SourceChangeSubmitted)
 
-class SourceCreatedPreviousVersion(SourceChange):
+    def __init__(self, link):
+        """Initialize link."""
+        # pylint:disable=super-init-not-called
+        self.link = link
+
+    def resolve_source_change_submitted(self, _):
+        """Resolve source change submitted link."""
+        from ..union import NotFound  # pylint:disable=import-outside-toplevel
+
+        event = find_one(
+            "EiffelSourceChangeSubmittedEvent", {"meta.id": self.link.get("target")}
+        )
+        if event is None:
+            return NotFound(self.link, "Could not find event in database.")
+        return SourceChangeSubmitted(event)
+
+
+class SourceCreatedPreviousVersion(graphene.ObjectType):
     """Previous source created link."""
+
+    source_change_created = graphene.Field(SourceChangeCreated)
+
+    def __init__(self, link):
+        """Initialize link."""
+        # pylint:disable=super-init-not-called
+        self.link = link
+
+    def resolve_source_change_created(self, _):
+        """Resolve source change created link."""
+        from ..union import NotFound  # pylint:disable=import-outside-toplevel
+
+        event = find_one(
+            "EiffelSourceChangeCreatedEvent", {"meta.id": self.link.get("target")}
+        )
+        if event is None:
+            return NotFound(self.link, "Could not find event in database.")
+        return SourceChangeCreated(event)


### PR DESCRIPTION
<!--
Filling out the template is required.
Any pull request that does not include enough information to be reviewed in a timely
manner may be closed at the maintainers' discretion.
Any pull request must pass all automated tests and, if applicable, code style checks.
In addition the pull request must contain tests that cover any new code.
-->

### Applicable Issues
<!--
Reference any relevant issues here. Every pull request should refer to at least one
issue. For exemptions to this rule, see the [contribution guidelines](./CONTRIBUTING.md).
If an issue can be closed when the PR is merged, please use the
[standard notation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
to link the PR to the issue and make sure the latter is closed automatically when the PR
is merged.
-->
No issue found or created.

### Description of the Change
<!--
Describe the change proposed and its benefits. The maintainers must be able to
understand the design of your change from this description. If we can't get a good idea
of what the code will be doing from this description, the pull request may be closed at
the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not
be familiar with or have worked with the sources addressed by this PR recently, so
please walk us through the concepts. Provide special attention to breaking changes.
-->
The `link` property was to properly setup when we tried to use inheritance, remove that inheritance and explicitly set up the previous version links for source change created and source change submitted.
I did not find any other obvious places where there were similar problems.

### Alternate Designs
<!--
Explain what other alternates were considered and why the proposed version was selected.
-->
I could probably add a `__init__` method to the link types instead and do `super().__init__()` but I actually don't mind a more explicit, albeit duplicate, approach here. It also aligns better with the other parts of the link code.

### Possible Drawbacks
<!-- Describe the possible side-effects or negative impacts of this change. -->
Can't see any.

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Tobias Persson <tobias.persson@axis.com>
